### PR TITLE
feat(core): play a sound when Claude finishes responding

### DIFF
--- a/core/hooks/done-sound.sh
+++ b/core/hooks/done-sound.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# done-sound.sh: Stop hook — play a short sound when Claude finishes responding.
+# macOS: uses afplay with a system sound.
+# Linux: uses paplay (PulseAudio) or aplay as fallback.
+# Other platforms: exits silently.
+
+if [[ "$(uname)" == "Darwin" ]]; then
+  afplay /System/Library/Sounds/Glass.aiff 2>/dev/null || true
+elif command -v paplay &>/dev/null; then
+  paplay /usr/share/sounds/freedesktop/stereo/complete.oga 2>/dev/null || true
+elif command -v aplay &>/dev/null; then
+  aplay /usr/share/sounds/alsa/Front_Center.wav 2>/dev/null || true
+fi
+
+exit 0

--- a/core/skills/setup-wizard/SKILL.md
+++ b/core/skills/setup-wizard/SKILL.md
@@ -1012,7 +1012,7 @@ mkdir -p ~/.claude/hooks
 
 # Core hooks (always — skip any the user chose to "keep yours" in Phase 2)
 # NOTE: statusline.sh is NOT a hook — it's configured separately via settings.json "statusLine"
-for hook in checklist-reminder.sh git-sync.sh session-start.sh title-update.sh todo-capture.sh write-guard.sh; do
+for hook in checklist-reminder.sh done-sound.sh git-sync.sh session-start.sh title-update.sh todo-capture.sh write-guard.sh; do
   ln -sf "$TOOLKIT_ROOT/core/hooks/$hook" ~/.claude/hooks/$hook
 done
 


### PR DESCRIPTION
## Summary

- Adds `done-sound.sh`, a `Stop` hook that plays a short system sound each time Claude finishes a response
- Useful when Claude is handling a long task and you've switched to another window
- macOS: plays `Glass.aiff` via `afplay`
- Linux: falls back to `paplay` (PulseAudio) or `aplay` (ALSA)
- Other platforms: exits silently — no errors, no noise

## Test plan

- [ ] Start a session, ask Claude something, confirm sound plays when response ends
- [ ] Verify hook exits cleanly with no output when sound plays successfully
- [ ] On a non-macOS system, verify hook exits silently without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)