### PR TITLE
Fix hook schema format — use nested hooks array

### DIFF
--- a/core/commands/update.md
+++ b/core/commands/update.md
@@ -197,7 +197,7 @@ Check for and install updates to the DestinClaude toolkit.
 
     ### 15b: Settings.json hook registrations
 
-    Read `~/.claude/settings.json` and verify all expected hooks are registered at the correct trigger points:
+    Read `~/.claude/settings.json` and verify all expected hooks are registered at the correct trigger points using the **nested `hooks` array format** (each entry must have a `hooks` array containing `{ "type": "command", "command": "..." }` objects — NOT a flat `command` property):
 
     | Hook | Trigger | Matcher |
     |------|---------|---------|
@@ -208,6 +208,8 @@ Check for and install updates to the DestinClaude toolkit.
     | `todo-capture.sh` | `UserPromptSubmit` | `.*` |
     | `checklist-reminder.sh` | `Stop` | `.*` |
 
+    Each entry must look like: `{ "matcher": "...", "hooks": [{ "type": "command", "command": "bash ~/.claude/hooks/foo.sh" }] }` — NOT `{ "command": "bash ~/.claude/hooks/foo.sh" }`.
+
     Also verify:
     ```json
     "statusLine": {
@@ -216,7 +218,7 @@ Check for and install updates to the DestinClaude toolkit.
     }
     ```
 
-    If any registrations are missing or the statusline isn't configured, offer to fix them by merging the correct entries into `settings.json`.
+    If any registrations are missing, use the wrong schema format, or the statusline isn't configured, offer to fix them by merging the correct entries into `settings.json`.
 
     ### 15c: Feature-by-feature diagnostic
 

--- a/core/skills/setup-wizard/SKILL.md
+++ b/core/skills/setup-wizard/SKILL.md
@@ -1032,7 +1032,67 @@ ln -sf "$TOOLKIT_ROOT/life/hooks/sync-encyclopedia.sh" ~/.claude/hooks/sync-ency
 
 Hooks must also be registered in `~/.claude/settings.json` under the `hooks` key so Claude Code invokes them at the right trigger points. Read the existing `settings.json` (create it if missing), then merge the toolkit's hook registrations into the `hooks` object. Preserve any existing hook entries the user chose to keep in Phase 2.
 
-Refer to the hook scripts themselves for the correct trigger point (`SessionStart`, `PreToolUse`, `PostToolUse`, `Stop`, `UserPromptSubmit`) and matcher pattern for each hook.
+**IMPORTANT — Hook schema:** Each hook entry MUST use the nested `hooks` array format. The `command` property goes inside a `hooks` array on each entry, NOT directly on the entry object. Here is the exact schema to generate:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [{ "type": "command", "command": "bash ~/.claude/hooks/session-start.sh" }]
+      },
+      {
+        "hooks": [{ "type": "command", "command": "bash ~/.claude/hooks/contribution-detector.sh" }]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [{ "type": "command", "command": "bash ~/.claude/hooks/todo-capture.sh" }]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [{ "type": "command", "command": "bash ~/.claude/hooks/write-guard.sh" }]
+      },
+      {
+        "hooks": [{ "type": "command", "command": "bash ~/.claude/hooks/tool-router.sh" }]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [{ "type": "command", "command": "bash ~/.claude/hooks/git-sync.sh" }]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [{ "type": "command", "command": "bash ~/.claude/hooks/personal-sync.sh" }]
+      },
+      {
+        "hooks": [{ "type": "command", "command": "bash ~/.claude/hooks/title-update.sh" }]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [{ "type": "command", "command": "bash ~/.claude/hooks/checklist-reminder.sh" }]
+      },
+      {
+        "hooks": [{ "type": "command", "command": "bash ~/.claude/hooks/done-sound.sh" }]
+      }
+    ]
+  }
+}
+```
+
+**Wrong format (will cause "Expected array, but received undefined" errors):**
+```json
+{ "command": "bash ~/.claude/hooks/foo.sh" }
+```
+
+**Correct format:**
+```json
+{ "hooks": [{ "type": "command", "command": "bash ~/.claude/hooks/foo.sh" }] }
+```
 
 #### 5d-ii: Register the statusline
 

--- a/core/specs/destinclaude-spec.md
+++ b/core/specs/destinclaude-spec.md
@@ -72,7 +72,7 @@ User runs: claude → /setup-wizard
 
 **Utility scripts** (`announcement-fetch.js`, `usage-fetch.js`) are not hooks themselves but are called by hooks as sibling files. They must be installed alongside hooks so they can be found at runtime. Hook scripts use a two-step discovery: (1) read `toolkit_root` from config, (2) fall back to symlink resolution.
 
-Hook trigger-point registration is written to `~/.claude/settings.json` under the `hooks` key. The statusline is **not** a hook — it requires a separate `statusLine` config entry in `settings.json`:
+Hook trigger-point registration is written to `~/.claude/settings.json` under the `hooks` key. Each hook entry uses the nested `hooks` array format: `{ "matcher": "...", "hooks": [{ "type": "command", "command": "bash ~/.claude/hooks/foo.sh" }] }`. The `command` property must NOT be placed directly on the entry object — it must be inside the `hooks` array. The statusline is **not** a hook — it requires a separate `statusLine` config entry in `settings.json`:
 
 ```json
 { "statusLine": { "type": "command", "command": "bash ~/.claude/statusline.sh" } }


### PR DESCRIPTION
The setup wizard was generating settings.json hooks with a flat `command` property on each entry, but Claude Code now requires the nested `hooks` array format:
  { "hooks": [{ "type": "command", "command": "..." }] }

The old flat format causes "Expected array, but received undefined" errors on fresh installs.

Changes:
- setup-wizard SKILL.md: Add explicit JSON schema example for Step 5d
- update.md: Note correct format in Step 15b verification
- destinclaude-spec.md: Document the required hook entry format