### PR TITLE
fix: trust folder prompt not appearing in chat view

### DIFF
--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -220,14 +220,43 @@ export function registerIpcHandlers(
     sessionManager.resizeSession(sessionId, cols, rows);
   });
 
-  // Forward PTY output to renderer
+  // --- PTY output buffering ---
+  // Buffer output per-session until the renderer signals its terminal is mounted.
+  // This prevents losing the initial trust prompt on slow systems where
+  // PTY output arrives before TerminalView mounts and registers its listener.
+  const pendingOutput = new Map<string, string[]>();
+  const readySessions = new Set<string>();
+
   sessionManager.on('pty-output', (sessionId: string, data: string) => {
-    send(IPC.PTY_OUTPUT, sessionId, data);
+    if (readySessions.has(sessionId)) {
+      send(IPC.PTY_OUTPUT, sessionId, data);
+    } else {
+      let buf = pendingOutput.get(sessionId);
+      if (!buf) {
+        buf = [];
+        pendingOutput.set(sessionId, buf);
+      }
+      buf.push(data);
+    }
+  });
+
+  // Renderer signals terminal is mounted and listening
+  ipcMain.on(IPC.TERMINAL_READY, (_event, sessionId: string) => {
+    readySessions.add(sessionId);
+    const buffered = pendingOutput.get(sessionId);
+    if (buffered) {
+      for (const data of buffered) {
+        send(IPC.PTY_OUTPUT, sessionId, data);
+      }
+      pendingOutput.delete(sessionId);
+    }
   });
 
   // Forward session exit events
   sessionManager.on('session-exit', (sessionId: string) => {
     send(IPC.SESSION_DESTROYED, sessionId);
+    pendingOutput.delete(sessionId);
+    readySessions.delete(sessionId);
   });
 
   // --- Status data poller ---

--- a/desktop/src/main/preload.ts
+++ b/desktop/src/main/preload.ts
@@ -20,6 +20,7 @@ const IPC = {
   READ_TRANSCRIPT_META: 'transcript:read-meta',
   SKILLS_LIST: 'skills:list',
   OPEN_CHANGELOG: 'shell:open-changelog',
+  TERMINAL_READY: 'session:terminal-ready',
 } as const;
 
 contextBridge.exposeInMainWorld('claude', {
@@ -33,6 +34,8 @@ contextBridge.exposeInMainWorld('claude', {
       ipcRenderer.send(IPC.SESSION_INPUT, sessionId, text),
     resize: (sessionId: string, cols: number, rows: number) =>
       ipcRenderer.send(IPC.SESSION_RESIZE, sessionId, cols, rows),
+    signalReady: (sessionId: string) =>
+      ipcRenderer.send(IPC.TERMINAL_READY, sessionId),
   },
   on: {
     sessionCreated: (cb: (info: any) => void) => {

--- a/desktop/src/renderer/components/TerminalView.tsx
+++ b/desktop/src/renderer/components/TerminalView.tsx
@@ -54,6 +54,10 @@ export default function TerminalView({ sessionId, visible }: Props) {
     fitAddonRef.current = fitAddon;
     registerTerminal(sessionId, terminal);
 
+    // Signal to main process that we're ready to receive PTY output.
+    // This flushes any buffered output that arrived before mount.
+    window.claude.session.signalReady(sessionId);
+
     // Fit terminal to container and sync dimensions to PTY
     const fitAndSync = () => {
       try {

--- a/desktop/src/renderer/hooks/useIpc.ts
+++ b/desktop/src/renderer/hooks/useIpc.ts
@@ -10,6 +10,7 @@ declare global {
         list: () => Promise<any[]>;
         sendInput: (sessionId: string, text: string) => void;
         resize: (sessionId: string, cols: number, rows: number) => void;
+        signalReady: (sessionId: string) => void;
       };
       skills: {
         list: () => Promise<import('../../shared/types').SkillEntry[]>;

--- a/desktop/src/renderer/parser/ink-select-parser.ts
+++ b/desktop/src/renderer/parser/ink-select-parser.ts
@@ -25,90 +25,100 @@ function stripAnsi(line: string): string {
 }
 
 /**
+ * Strip leading numbering ("1. ", "2. ") from an option label if present.
+ */
+function stripNumbering(text: string): string {
+  return text.replace(/^\d+\.\s+/, '');
+}
+
+/**
+ * Measure the leading whitespace of a raw line (before any trimming).
+ */
+function indentOf(line: string): number {
+  const m = line.match(/^(\s*)/);
+  return m ? m[1].length : 0;
+}
+
+/**
+ * Checks if a line looks like a menu option sibling:
+ * - non-empty
+ * - similar indentation to the reference (within +/-2 columns)
+ * - not a box-drawing or decorative line
+ */
+function isOptionLine(line: string, referenceIndent: number): boolean {
+  const trimmed = line.trim();
+  if (!trimmed) return false;
+  if (/^[─┌┐└┘│╭╮╯╰┬┴├┤┼╔╗╚╝║═]+$/.test(trimmed)) return false;
+  const indent = indentOf(line);
+  return Math.abs(indent - referenceIndent) <= 2;
+}
+
+/**
  * Parse an Ink select menu from rendered terminal screen text.
  *
- * Instead of walking line-by-line (fragile with wrapped text), this:
- * 1. Finds the ❯ selector character
- * 2. Extracts the full menu block (selector line + surrounding numbered options)
- * 3. Joins multi-line text into single options using numbered-item boundaries
+ * Handles both numbered ("1. Yes") and unnumbered ("Yes") option formats.
+ * Detection strategy:
+ * 1. Finds the ❯ selector character (bottom-up scan)
+ * 2. Extracts the selected option's text and indentation
+ * 3. Walks up/down from the selector to find sibling option lines
+ *    at matching indentation
+ * 4. Strips optional numbering from all options
  */
 export function parseInkSelect(screenText: string): ParsedMenu | null {
   const clean = stripAnsi(screenText);
   const lines = clean.split('\n');
 
-  // Find the line with the ❯ selector
+  // Find the line with the ❯ selector (search bottom-up for the most recent)
   let selectorIdx = -1;
   for (let i = lines.length - 1; i >= 0; i--) {
     if (/^\s*❯/.test(lines[i])) { selectorIdx = i; break; }
   }
   if (selectorIdx < 0) return null;
 
-  // Collect the full menu region: walk up and down from the selector
-  // to find all numbered option lines and their continuations
-  let regionStart = selectorIdx;
-  let regionEnd = selectorIdx;
+  const selectorLine = lines[selectorIdx];
+  // The selected option text is everything after ❯ and whitespace
+  const selectedText = stripNumbering(selectorLine.replace(/^\s*❯\s*/, '').trim());
+  if (!selectedText) return null;
 
-  // Walk backward to find the start of the menu
+  // Determine the reference indentation for non-selected options.
+  // Non-selected lines use spaces where ❯ appears on the selected line.
+  // Example:  "  ❯ Yes"  ->  selected indent = 4 (after ❯ + space)
+  //           "    No"   ->  sibling indent = 4 (matching spaces)
+  // We use the indentation of the text AFTER the ❯ to find siblings.
+  const afterSelector = selectorLine.replace(/^\s*❯/, ' ');
+  const referenceIndent = indentOf(afterSelector);
+
+  const options: string[] = [];
+  let selectedIndex = 0;
+
+  // Walk backward to find options above the selector
   for (let i = selectorIdx - 1; i >= 0; i--) {
     const trimmed = lines[i].trim();
     if (!trimmed) break;
-    // A numbered option or heavily-indented continuation
-    if (/^\d+\.\s+/.test(trimmed) || /^\s{2,}/.test(lines[i])) {
-      regionStart = i;
-    } else {
-      break;
-    }
+    if (!isOptionLine(lines[i], referenceIndent)) break;
+    // Don't include lines that look like titles (end with ? or :)
+    if (/[?:]$/.test(trimmed) && !/^\d+\.\s+/.test(trimmed)) break;
+    options.unshift(stripNumbering(trimmed));
   }
 
-  // Walk forward to find the end of the menu
+  // Insert the selected option
+  selectedIndex = options.length;
+  options.push(selectedText);
+
+  // Walk forward to find options below the selector
   for (let i = selectorIdx + 1; i < lines.length; i++) {
     const trimmed = lines[i].trim();
     if (!trimmed) break;
-    if (/^\d+\.\s+/.test(trimmed) || /^\s{2,}/.test(lines[i])) {
-      regionEnd = i;
-    } else {
-      break;
-    }
-  }
-
-  // Flatten the region into a single string, collapsing internal newlines
-  // Then split on numbered-item boundaries to extract individual options
-  const regionLines = lines.slice(regionStart, regionEnd + 1);
-  const regionText = regionLines.map((l) => {
-    // Normalize: strip selector ❯ and leading whitespace, keep the rest
-    return l.replace(/^\s*❯\s*/, '  ');
-  }).join(' ');
-
-  // Match numbered options: "1. text", "2. text", etc.
-  // Use a regex that captures everything from one number to the next
-  const optionPattern = /(\d+)\.\s+(.+?)(?=\s+\d+\.\s+|$)/g;
-  const options: string[] = [];
-  const optionNumbers: number[] = [];
-  let match;
-
-  while ((match = optionPattern.exec(regionText)) !== null) {
-    const num = parseInt(match[1], 10);
-    // Clean up whitespace (from joining multi-line text)
-    const text = match[2].replace(/\s+/g, ' ').trim();
-    options.push(text);
-    optionNumbers.push(num);
+    if (!isOptionLine(lines[i], referenceIndent)) break;
+    options.push(stripNumbering(trimmed));
   }
 
   if (options.length < 2) return null;
   if (options.some((o) => o.length > 200)) return null;
 
-  // Determine which option is selected (the one on the ❯ line)
-  const selectorLine = lines[selectorIdx];
-  const selectorNumMatch = /❯\s*(\d+)\./.exec(selectorLine);
-  let selectedIndex = 0;
-  if (selectorNumMatch) {
-    const selNum = parseInt(selectorNumMatch[1], 10);
-    const idx = optionNumbers.indexOf(selNum);
-    if (idx >= 0) selectedIndex = idx;
-  }
-
   // Extract title from lines above the menu
-  const title = extractTitle(lines, regionStart, clean);
+  const firstOptionLine = selectorIdx - selectedIndex;
+  const title = extractTitle(lines, Math.max(0, firstOptionLine), clean);
 
   const id = 'menu_' + options.map((o) => o.slice(0, 10)).join('_')
     .toLowerCase().replace(/[^a-z0-9_]/g, '');

--- a/desktop/src/renderer/state/chat-reducer.ts
+++ b/desktop/src/renderer/state/chat-reducer.ts
@@ -208,7 +208,7 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
       if (!session) return state;
 
       const timeline = session.timeline.filter(
-        (e) => !(e.kind === 'prompt' && e.prompt.promptId === action.promptId),
+        (e) => !(e.kind === 'prompt' && e.prompt.promptId === action.promptId && !e.prompt.completed),
       );
 
       next.set(action.sessionId, { ...session, timeline });

--- a/desktop/src/shared/types.ts
+++ b/desktop/src/shared/types.ts
@@ -63,6 +63,7 @@ export const IPC = {
   SESSION_RESIZE: 'session:resize',
   SESSION_LIST: 'session:list',
   SKILLS_LIST: 'skills:list',
+  TERMINAL_READY: 'session:terminal-ready',
   // Main -> Renderer
   SESSION_CREATED: 'session:created',
   SESSION_DESTROYED: 'session:destroyed',


### PR DESCRIPTION
## Summary

- **Parser rewrite**: Ink select parser now detects menu options by indentation alignment relative to the selector instead of requiring numbered format. Backward-compatible with numbered menus.
- **PTY output buffering**: Added per-session output buffering in the main process that holds data until the renderer signals TERMINAL_READY, eliminating the race condition where early PTY output was silently dropped before TerminalView mounted.
- **Dismiss guard**: DISMISS_PROMPT no longer removes completed prompts from the timeline, so the confirmation checkmark persists after the user makes a selection.

## Files changed (7)

| File | Fix |
|------|-----|
| ink-select-parser.ts | Indentation-based option detection (Fix 1) |
| ipc-handlers.ts | PTY output buffering + TERMINAL_READY handler + cleanup (Fix 2) |
| preload.ts | IPC constant + signalReady bridge method (Fix 2) |
| types.ts | TERMINAL_READY IPC channel (Fix 2) |
| useIpc.ts | signalReady Window type declaration (Fix 2) |
| TerminalView.tsx | Call signalReady() after terminal setup (Fix 2) |
| chat-reducer.ts | completed guard on DISMISS_PROMPT (Fix 3) |

## Test plan

- [ ] Launch app, create a new session - trust prompt should appear as a PromptCard in chat view and as the TrustGate overlay
- [ ] Click Yes, proceed - checkmark confirmation should persist in the timeline
- [ ] Switch to terminal view - verify the trust prompt also renders correctly in the raw terminal
- [ ] Test with a slow system or artificial delay - buffered output should still deliver the trust prompt
- [ ] Test permission prompts (e.g., file read) - verify they still render as PromptCards in chat view

Generated with [Claude Code](https://claude.com/claude-code)