### PR TITLE
fix(desktop): fix node-pty spawn-helper path double-replacement on macOS

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -4,6 +4,7 @@
   "description": "Desktop GUI for Claude Code with the DestinClaude toolkit",
   "main": "dist/main/main.js",
   "scripts": {
+    "postinstall": "node scripts/patch-node-pty.js",
     "dev": "concurrently \"npm run dev:renderer\" \"wait-on http://localhost:5173 && npm run dev:main\"",
     "dev:main": "tsc -p tsconfig.json && node -e \"require('fs').cpSync('src/main/pty-worker.js','dist/main/pty-worker.js')\" && electron .",
     "dev:renderer": "vite",

--- a/desktop/scripts/patch-node-pty.js
+++ b/desktop/scripts/patch-node-pty.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/**
+ * Patches node-pty's unixTerminal.js to fix a double-replacement bug that
+ * causes `posix_spawn failed: No such file or directory` when spawning a PTY
+ * from system Node.js (as opposed to Electron's Node.js).
+ *
+ * Root cause: node-pty does `.replace('app.asar', 'app.asar.unpacked')` to
+ * redirect spawn-helper to the unpacked path. When loaded by Electron, paths
+ * are virtual (e.g. `app.asar/...`) so the replacement works correctly. But
+ * when loaded by system Node.js (which is how pty-worker.js runs), the path
+ * already resolves to `app.asar.unpacked/...` on disk, so the replacement
+ * double-fires and produces `app.asar.unpacked.unpacked/...`, which doesn't exist.
+ *
+ * Fix: use a negative lookahead so the replacement only applies when the path
+ * does NOT already contain `app.asar.unpacked`.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const target = path.join(__dirname, '../node_modules/node-pty/lib/unixTerminal.js');
+
+if (!fs.existsSync(target)) {
+  console.log('patch-node-pty: file not found, skipping');
+  process.exit(0);
+}
+
+const original = "helperPath.replace('app.asar', 'app.asar.unpacked')";
+const patched = "helperPath.replace(/app\\.asar(?!\\.unpacked)/, 'app.asar.unpacked')";
+
+let content = fs.readFileSync(target, 'utf8');
+if (content.includes(patched)) {
+  console.log('patch-node-pty: already patched, skipping');
+  process.exit(0);
+}
+
+if (!content.includes(original)) {
+  console.log('patch-node-pty: pattern not found (may be a newer node-pty version), skipping');
+  process.exit(0);
+}
+
+content = content.replace(original, patched);
+fs.writeFileSync(target, content);
+console.log('patch-node-pty: patched unixTerminal.js — spawn-helper path resolution fixed');


### PR DESCRIPTION
## Summary

- Adds `desktop/scripts/patch-node-pty.js` — a postinstall script that patches `node-pty/lib/unixTerminal.js` with a regex fix
- Adds `"postinstall": "node scripts/patch-node-pty.js"` to `desktop/package.json` so the patch applies automatically after `npm install`

## Root Cause

When `pty-worker.js` runs under **system Node.js** (not Electron), the path to `spawn-helper` already resolves to the real path on disk: `.../app.asar.unpacked/node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper`.

`unixTerminal.js` then applies:
```js
helperPath = helperPath.replace('app.asar', 'app.asar.unpacked');
```

This was designed for Electron's virtual filesystem where paths show as `app.asar/...`. But since the path already contains `app.asar.unpacked`, the replacement produces `app.asar.unpacked.unpacked/...` — which doesn't exist.

Result: `posix_spawn failed: No such file or directory` → PTY session exits immediately → app snaps back to splash screen.

## Fix

The patch replaces the string `.replace()` with a regex using a negative lookahead:
```js
// Before
helperPath.replace('app.asar', 'app.asar.unpacked')
// After
helperPath.replace(/app\.asar(?!\.unpacked)/, 'app.asar.unpacked')
```

This only fires when the path does **not** already contain `app.asar.unpacked`, making it safe in both Electron and system Node.js contexts.

## Test Plan

- [ ] `npm install` in `desktop/` runs postinstall without errors
- [ ] Click "create session" in DestinCode — session stays open (no snap back to splash)
- [ ] Verify on macOS arm64 (where this was reproduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)