### PR TITLE
Record Claude Code version in releases

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -44,6 +44,15 @@ fi
 
 echo "Releasing v$VERSION (currently v$CURRENT)"
 
+# Capture upstream Claude Code version
+CLAUDE_VERSION=""
+if command -v claude >/dev/null 2>&1; then
+    CLAUDE_VERSION=$(claude --version 2>/dev/null | head -1 || echo "unknown")
+    echo "Claude Code version: $CLAUDE_VERSION"
+else
+    echo "Warning: claude CLI not found — Claude Code version will not be recorded"
+fi
+
 # 1. Bump VERSION
 echo "$VERSION" > VERSION
 
@@ -55,12 +64,26 @@ node -e "var p='desktop/package.json',pkg=JSON.parse(require('fs').readFileSync(
 
 # 4. Add CHANGELOG header (portable: awk instead of GNU-only sed 0,/ADDR/ syntax)
 TODAY=$(date +%Y-%m-%d)
-awk -v ver="$VERSION" -v today="$TODAY" 'BEGIN{done=0} /^## / && !done {printf "## v%s (%s)\n\n_(fill in release notes)_\n\n", ver, today; done=1} {print}' CHANGELOG.md > CHANGELOG.md.tmp && mv CHANGELOG.md.tmp CHANGELOG.md
+if [[ -n "$CLAUDE_VERSION" ]]; then
+    CLAUDE_NOTE="Built on $CLAUDE_VERSION"
+else
+    CLAUDE_NOTE=""
+fi
+awk -v ver="$VERSION" -v today="$TODAY" -v cnote="$CLAUDE_NOTE" 'BEGIN{done=0} /^## / && !done {printf "## [%s] - %s\n\n", ver, today; if (cnote != "") printf "_(%s)_\n\n", cnote; printf "_(fill in release notes)_\n\n"; done=1} {print}' CHANGELOG.md > CHANGELOG.md.tmp && mv CHANGELOG.md.tmp CHANGELOG.md
 
 # 5. Commit, tag, push
 git add VERSION plugin.json desktop/package.json CHANGELOG.md
 git commit -m "release: v$VERSION"
-git tag "v$VERSION"
+if [[ -n "$CLAUDE_VERSION" ]]; then
+    git tag -a "v$VERSION" -m "$(cat <<TAGEOF
+Release v$VERSION
+
+Built on $CLAUDE_VERSION
+TAGEOF
+)"
+else
+    git tag -a "v$VERSION" -m "Release v$VERSION"
+fi
 git push origin master --tags
 
 echo ""


### PR DESCRIPTION
## Summary
- `scripts/release.sh` now captures the upstream Claude Code version (`claude --version`) during release and embeds it in both the CHANGELOG header and an annotated git tag
- Fixes the CHANGELOG header format from `## vX.Y.Z (date)` to `## [X.Y.Z] - date` to match existing entries
- Gracefully handles missing `claude` CLI by skipping version recording with a warning

## Test plan
- [ ] Run `release.sh` with `claude` CLI installed and verify CHANGELOG entry includes `_(Built on ...)_` line
- [ ] Run `release.sh` without `claude` CLI and verify warning is printed and release proceeds without version note
- [ ] Verify `git show v<version>` displays annotated tag with Claude Code version in the message
- [ ] Confirm CHANGELOG header format matches existing entries (`## [X.Y.Z] - YYYY-MM-DD`)

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)