### PR TITLE
Fix orphan detector — distinguish user skills from stale symlinks

### DIFF
--- a/scripts/post-update.sh
+++ b/scripts/post-update.sh
@@ -585,8 +585,13 @@ phase_orphans() {
       local skill_name
       skill_name="$(basename "$skill")"
       if ! printf '%b' "$known_skills" | grep -qxF "$skill_name"; then
-        emit "ORPHAN" "skills/$skill_name" "not in toolkit manifest"
-        orphan_count=$((orphan_count + 1))
+        if [ -L "$skill" ]; then
+          # Symlink not in manifest = stale toolkit artifact
+          emit "ORPHAN" "skills/$skill_name" "stale symlink — not in toolkit manifest"
+          orphan_count=$((orphan_count + 1))
+        else
+          emit "SKIP" "skills/$skill_name" "user-managed skill (not a toolkit symlink)"
+        fi
       fi
     done
   fi


### PR DESCRIPTION
## Summary
- The orphan detector in `post-update.sh` now checks whether unrecognized skills in `~/.claude/skills/` are symlinks or real directories
- Real directories are skipped as user-managed skills (emitting `SKIP` instead of `ORPHAN`)
- Only symlinks not found in the toolkit manifest are flagged as orphans, correctly targeting stale toolkit artifacts

Closes #67

## Test plan
- [ ] Run `post-update.sh` with a user-managed skill (real directory) not in manifest -- should emit `SKIP`
- [ ] Run `post-update.sh` with a stale symlink not in manifest -- should emit `ORPHAN`
- [ ] Run `post-update.sh` with all skills in manifest -- no orphans or skips

🤖 Generated with [Claude Code](https://claude.com/claude-code)