### PR TITLE
Human-friendly tool card labels in desktop app

### DIFF
--- a/desktop/src/renderer/components/ToolCard.tsx
+++ b/desktop/src/renderer/components/ToolCard.tsx
@@ -4,40 +4,197 @@ import { useChatDispatch } from '../state/chat-context';
 import { CheckIcon, FailIcon, ChevronIcon } from './Icons';
 import BrailleSpinner from './BrailleSpinner';
 
-const TOOL_LABELS: Record<string, string> = {
-  Read: 'Read File',
-  Write: 'Write File',
-  Edit: 'Edit File',
-  Bash: 'Run Command',
-  Glob: 'Find Files',
-  Grep: 'Search Code',
-  WebFetch: 'Fetch URL',
-  WebSearch: 'Web Search',
-  Agent: 'Sub-Agent',
-  NotebookEdit: 'Edit Notebook',
-};
+// --- Helpers for friendly display ---
 
-function toolLabel(name: string): string {
-  return TOOL_LABELS[name] || name;
+function basename(filepath: string): string {
+  const parts = filepath.replace(/\\/g, '/').split('/');
+  return parts[parts.length - 1] || parts[parts.length - 2] || filepath;
 }
 
-function toolSummary(tool: ToolCallState): string {
+function parentDir(filepath: string): string {
+  const parts = filepath.replace(/\\/g, '/').split('/').filter(Boolean);
+  return parts.length >= 2 ? parts[parts.length - 2] + '/' : '';
+}
+
+function titleCase(s: string): string {
+  return s.replace(/[-_]/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+}
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max) + '…' : s;
+}
+
+function friendlyToolDisplay(tool: ToolCallState): { label: string; detail: string } {
   const { toolName, input } = tool;
+
   switch (toolName) {
-    case 'Read':
-      return (input.file_path as string) || '';
-    case 'Write':
-      return (input.file_path as string) || '';
-    case 'Edit':
-      return (input.file_path as string) || '';
-    case 'Bash':
-      return (input.command as string) || '';
-    case 'Glob':
-      return (input.pattern as string) || '';
-    case 'Grep':
-      return (input.pattern as string) || '';
-    default:
-      return '';
+    case 'Bash': {
+      const cmd = (input.command as string) || '';
+      const desc = input.description as string | undefined;
+      const bg = input.run_in_background ? ' ⟳' : '';
+      let label: string;
+      if (desc) {
+        label = desc;
+      } else if (cmd) {
+        const firstBin = cmd.trimStart().split(/\s+/)[0] || 'command';
+        label = `Running ${basename(firstBin)}`;
+      } else {
+        label = 'Run Command';
+      }
+      return { label: label + bg, detail: cmd ? `↳ ${truncate(cmd, 80)}` : '' };
+    }
+
+    case 'Read': {
+      const fp = (input.file_path as string) || '';
+      const label = fp ? `Reading ${basename(fp)}` : 'Reading File';
+      let detail = fp ? `↳ ${parentDir(fp)}` : '';
+      const offset = input.offset as number | undefined;
+      const limit = input.limit as number | undefined;
+      const pages = input.pages as string | undefined;
+      if (offset != null && limit != null) {
+        detail += ` lines ${offset}-${offset + limit}`;
+      } else if (offset != null) {
+        detail += ` from line ${offset}`;
+      } else if (limit != null) {
+        detail += ` first ${limit} lines`;
+      }
+      if (pages) {
+        detail += ` pages ${pages}`;
+      }
+      return { label, detail };
+    }
+
+    case 'Write': {
+      const fp = (input.file_path as string) || '';
+      return {
+        label: fp ? `Writing ${basename(fp)}` : 'Writing File',
+        detail: fp ? `↳ ${parentDir(fp)}` : '',
+      };
+    }
+
+    case 'Edit': {
+      const fp = (input.file_path as string) || '';
+      let detail = fp ? `↳ ${parentDir(fp)}` : '';
+      const oldStr = input.old_string as string | undefined;
+      if (oldStr) {
+        detail += ` ${truncate(oldStr.replace(/\n/g, '⏎'), 40)}`;
+      }
+      return {
+        label: fp ? `Editing ${basename(fp)}` : 'Editing File',
+        detail,
+      };
+    }
+
+    case 'Grep': {
+      const pattern = (input.pattern as string) || '';
+      const label = pattern ? `Searching for "${truncate(pattern, 30)}"` : 'Searching Code';
+      let detail = '';
+      if (input.glob) {
+        detail = `↳ in ${input.glob} files`;
+      } else if (input.path) {
+        detail = `↳ in ${basename(input.path as string)}/`;
+      } else if (input.type) {
+        detail = `↳ in .${input.type} files`;
+      }
+      return { label, detail };
+    }
+
+    case 'Glob': {
+      const pattern = (input.pattern as string) || '';
+      const simplified = pattern.replace(/^\*\*\//, '');
+      const label = pattern ? `Finding ${simplified} files` : 'Finding Files';
+      const detail = input.path ? `↳ in ${basename(input.path as string)}/` : '';
+      return { label, detail };
+    }
+
+    case 'Agent': {
+      const desc = input.description as string | undefined;
+      const bg = input.run_in_background ? ' ⟳' : '';
+      const label = desc ? `Agent: ${desc}` : 'Running Sub-Agent';
+      const detail = input.subagent_type ? `↳ ${input.subagent_type}` : '';
+      return { label: label + bg, detail };
+    }
+
+    case 'WebSearch': {
+      const query = input.query as string | undefined;
+      return {
+        label: 'Searching the Web',
+        detail: query ? `↳ ${query}` : '',
+      };
+    }
+
+    case 'WebFetch': {
+      const url = input.url as string | undefined;
+      let domain = '';
+      if (url) {
+        try {
+          domain = new URL(url).hostname;
+        } catch {
+          domain = url;
+        }
+      }
+      return {
+        label: 'Fetching Webpage',
+        detail: domain ? `↳ ${domain}` : '',
+      };
+    }
+
+    case 'Skill': {
+      const skill = input.skill as string | undefined;
+      const args = input.args as string | undefined;
+      return {
+        label: skill ? `Running /${skill}` : 'Running Skill',
+        detail: args ? `↳ ${args}` : '',
+      };
+    }
+
+    case 'TaskCreate': {
+      const subject = (input.subject as string) || '';
+      return {
+        label: subject ? `New Task: ${truncate(subject, 50)}` : 'New Task',
+        detail: '',
+      };
+    }
+
+    case 'TaskUpdate': {
+      const status = input.status as string | undefined;
+      let label: string;
+      switch (status) {
+        case 'completed':
+          label = 'Task Completed';
+          break;
+        case 'in_progress':
+          label = 'Task Started';
+          break;
+        case 'deleted':
+          label = 'Task Deleted';
+          break;
+        default:
+          label = 'Updating Task';
+      }
+      const taskId = input.taskId as string | undefined;
+      return { label, detail: taskId ? `↳ #${taskId}` : '' };
+    }
+
+    default: {
+      // MCP tools: mcp__{server}__{action}
+      if (toolName.startsWith('mcp__')) {
+        const parts = toolName.slice(5).split('__');
+        const server = parts[0] ? titleCase(parts[0]) : toolName;
+        const action = parts[1] ? titleCase(parts[1]) : '';
+        const label = action ? `${server}: ${action}` : server;
+        // Show the most interesting input value as detail
+        let detail = '';
+        const values = Object.values(input).filter(v => typeof v === 'string' && v.length > 0) as string[];
+        if (values.length > 0) {
+          detail = `↳ ${truncate(values[0], 60)}`;
+        }
+        return { label, detail };
+      }
+
+      // Unknown tool — show name as-is
+      return { label: toolName, detail: '' };
+    }
   }
 }
 
@@ -104,7 +261,7 @@ interface Props {
 export default function ToolCard({ tool, sessionId }: Props) {
   const [expanded, setExpanded] = useState(false);
   const dispatch = useChatDispatch();
-  const summary = toolSummary(tool);
+  const display = friendlyToolDisplay(tool);
 
   return (
     <div className="border border-gray-700 rounded-lg bg-gray-850 overflow-hidden">
@@ -124,9 +281,9 @@ export default function ToolCard({ tool, sessionId }: Props) {
           <FailIcon className="w-3.5 h-3.5 shrink-0 text-gray-400" />
         )}
         <span className="text-gray-600 text-xs select-none">|</span>
-        <span className="text-xs font-medium text-gray-300">{toolLabel(tool.toolName)}</span>
-        {summary && (
-          <span className="text-xs text-gray-500 truncate flex-1 min-w-0">{summary}</span>
+        <span className="text-xs font-medium text-gray-300">{display.label}</span>
+        {display.detail && (
+          <span className="text-xs text-gray-500 truncate flex-1 min-w-0">{display.detail}</span>
         )}
         <ChevronIcon className="w-3.5 h-3.5 shrink-0 text-gray-500" expanded={expanded} />
       </button>


### PR DESCRIPTION
## Summary
- Replaced the static `TOOL_LABELS` map, `toolLabel()`, and `toolSummary()` with a single `friendlyToolDisplay()` function that returns contextual `{ label, detail }` for every tool type
- Bash tools now show Claude's `input.description` field (e.g., "Checking GitHub commits") instead of generic "Run Command", with the truncated command as detail
- Read/Write/Edit show "Reading filename" with parent directory context and optional line/page ranges
- Grep/Glob show natural language labels like `Searching for "pattern"` with file type/path detail
- MCP tools are parsed from `mcp__server__action` into "Server: Action" format (e.g., "Todoist: Find Tasks")
- Agent, Skill, Task, WebSearch, WebFetch all get purpose-built labels
- Raw inputs remain available in the expandable detail view

## Test plan
- [ ] Verify Bash tool cards show description text when Claude provides it, and fall back to binary name parsing when it does not
- [ ] Verify Read/Write/Edit cards show the filename with parent folder in detail
- [ ] Verify Grep cards show the search pattern in quotes and file type/glob context
- [ ] Verify MCP tool cards parse `mcp__todoist__find-tasks` into "Todoist: Find Tasks"
- [ ] Verify unknown/new tools fall back to showing the raw tool name
- [ ] Verify expanding a tool card still shows full JSON input and response
- [ ] Verify background tasks show the ⟳ indicator on Bash and Agent labels

Closes #72

Generated with [Claude Code](https://claude.com/claude-code)