### PR TITLE
Update docs for release skill and self-hosted icons

### DIFF
--- a/core/specs/landing-page-spec.md
+++ b/core/specs/landing-page-spec.md
@@ -103,7 +103,7 @@ Framing: rounded rect with accent-color border + subtle horizontal accent lines 
 - Positioned between prerequisites and the install step
 - Intro text: "DestinClaude integrates with the services you already use."
 - Center-justified flexbox row of integration tags (pill-shaped), each with:
-  - Icon (via Wikimedia Commons SVGs for Google/Apple services, Simple Icons CDN for others, Google Favicons as fallback)
+  - Icon (self-hosted SVGs in `docs/icons/`, originally sourced from Wikimedia Commons and Simple Icons)
   - Service name
   - `data-desc` attribute with expandable description (click/tap to toggle)
   - Descriptions use consistent "DestinClaude can..." phrasing

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -215,7 +215,7 @@ Three GitHub Actions workflows handle versioning, releases, and builds:
 | `release.yml` | Push of a `v*` tag | Extracts the matching section from `CHANGELOG.md` and creates a GitHub Release |
 | `build.yml` | Push of a `v*` tag | Builds cross-platform DestinCode desktop app installers (Windows `.exe`, macOS `.dmg`, Linux `.AppImage`) |
 
-**Release flow:** Bump the `version` field in `plugin.json` → push to master → `auto-tag.yml` creates the tag → tag push triggers `release.yml` → GitHub Release published with changelog notes. No manual tagging needed.
+**Release flow:** The `/release` skill orchestrates the full release process — 7 parallel review agents validate changes, then it bumps `VERSION`, `plugin.json`, and `desktop/package.json`, generates the CHANGELOG entry, captures the Claude Code version, triggers a build verification, commits, tags, and pushes. From there, `auto-tag.yml` creates the tag → tag push triggers `release.yml` → GitHub Release published with changelog notes → `build.yml` builds and attaches desktop installers.
 
 **Versioning policy** (documented in CHANGELOG.md):
 - **Major (X.0.0)** — Breaking changes requiring `/setup-wizard` re-run or manual migration
@@ -223,6 +223,8 @@ Three GitHub Actions workflows handle versioning, releases, and builds:
 - **Patch (1.0.X)** — Bug fixes, doc/copy updates, hook corrections
 
 The `VERSION` file and `plugin.json` version field must stay in sync. The `/update` command and statusline both read from `VERSION` to determine the installed version and check for updates via git tags.
+
+The `/release` skill (in `destinclaude-admin`) is the sole release mechanism. `scripts/release.sh` was removed in v2.1.9 — all release logic now lives in the skill.
 
 ## Building on Top
 


### PR DESCRIPTION
## Summary
- **system-architecture.md**: Updated the Release flow paragraph to describe the `/release` skill as the sole release mechanism (7 parallel review agents, version bumping across `VERSION`/`plugin.json`/`desktop/package.json`, CHANGELOG generation, build verification). Added note that `scripts/release.sh` was removed in v2.1.9.
- **landing-page-spec.md**: Updated the Integrations icon source description from CDN-loaded (Wikimedia Commons, Simple Icons CDN, Google Favicons) to self-hosted SVGs in `docs/icons/`.

## Test plan
- [ ] Verify `docs/system-architecture.md` renders correctly on GitHub
- [ ] Verify `core/specs/landing-page-spec.md` renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)