### PR TITLE
chore(hooks): remove Gmail and Calendar redirects from tool-router

### DIFF
--- a/hooks/tool-router.sh
+++ b/hooks/tool-router.sh
@@ -1,71 +1,22 @@
 #!/bin/bash
-# PreToolUse hook: blocks Claude.ai native Gmail and Google Calendar MCP tools
-# and redirects to equivalent GWS CLI commands.
+# PreToolUse hook: tool router.
 #
-# Claude.ai MCP tools blocked:
-#   mcp__claude_ai_Gmail__gmail_search_messages  → gws gmail users messages list
-#   mcp__claude_ai_Gmail__gmail_read_message      → gws gmail users messages get
-#   mcp__claude_ai_Google_Calendar__gcal_list_calendars → gws calendar calendarList list
-#   mcp__claude_ai_Google_Calendar__gcal_create_event   → gws calendar events insert
-#   mcp__claude_ai_Google_Calendar__gcal_list_events    → gws calendar events list
+# Previously this hook blocked Claude.ai's native Gmail and Google Calendar MCP
+# tools and redirected callers to "gws" CLI equivalents. The google-services
+# marketplace bundle now provides real Gmail/Calendar skills built on gws, so
+# the redirect-to-not-yet-built-gws shim is no longer needed and has been
+# removed. See docs/superpowers/specs/2026-04-16-google-services-design.md.
+#
+# The hook is kept in place (empty pass-through) so that future tool-routing
+# rules can be added here without re-wiring the hooks manifest.
 
 # Source shared infrastructure (trap handlers, error capture, rotation)
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 [[ -f "$HOOK_DIR/lib/hook-preamble.sh" ]] && source "$HOOK_DIR/lib/hook-preamble.sh"
 
-STDIN_JSON=$(cat)
-TOOL_NAME=$(echo "$STDIN_JSON" | node -e "
-  let d='';
-  process.stdin.on('data',c=>d+=c);
-  process.stdin.on('end',()=>{
-    try { console.log(JSON.parse(d).tool_name||''); }
-    catch { console.log(''); }
-  });
-" 2>/dev/null)
+# Drain stdin (Claude Code always pipes JSON to PreToolUse hooks) so we don't
+# leave a broken pipe for the caller.
+cat >/dev/null
 
-# Only act on Claude.ai Gmail and Google Calendar MCP tools
-case "$TOOL_NAME" in
-  mcp__claude_ai_Gmail__gmail_search_messages)
-    echo "BLOCKED: Claude.ai Gmail MCP is disabled. Use GWS CLI instead:"
-    echo "  gws gmail users messages list --user-id me --q 'search query' --format json"
-    echo ""
-    echo "Common flags: --q (Gmail search syntax), --max-results N, --label-ids LABEL"
-    exit 1
-    ;;
-  mcp__claude_ai_Gmail__gmail_read_message)
-    echo "BLOCKED: Claude.ai Gmail MCP is disabled. Use GWS CLI instead:"
-    echo "  gws gmail users messages get --user-id me --id MESSAGE_ID --format json"
-    echo ""
-    echo "Use --format full for headers+body, --format metadata for headers only."
-    exit 1
-    ;;
-  mcp__claude_ai_Google_Calendar__gcal_list_calendars)
-    echo "BLOCKED: Claude.ai Google Calendar MCP is disabled. Use GWS CLI instead:"
-    echo "  gws calendar calendarList list --format json"
-    exit 1
-    ;;
-  mcp__claude_ai_Google_Calendar__gcal_create_event)
-    echo "BLOCKED: Claude.ai Google Calendar MCP is disabled. Use GWS CLI instead:"
-    echo "  gws calendar events insert --calendar-id primary --fields 'summary,start,end,description'"
-    echo "  gws calendar events quickAdd --calendar-id primary --text 'Meeting tomorrow at 3pm'"
-    echo ""
-    echo "For structured events, pipe JSON body via stdin or use individual flags."
-    exit 1
-    ;;
-  mcp__claude_ai_Google_Calendar__gcal_list_events)
-    echo "BLOCKED: Claude.ai Google Calendar MCP is disabled. Use GWS CLI instead:"
-    echo "  gws calendar events list --calendar-id primary --time-min 2024-01-01T00:00:00Z --format json"
-    echo ""
-    echo "Common flags: --time-min, --time-max, --q 'search', --max-results N, --single-events"
-    exit 1
-    ;;
-  mcp__claude_ai_Gmail__*|mcp__claude_ai_Google_Calendar__*)
-    # Catch-all for any future Claude.ai Gmail/Calendar tools
-    echo "BLOCKED: Claude.ai Gmail/Calendar MCP tools are disabled."
-    echo "Use the GWS CLI instead: gws gmail --help / gws calendar --help"
-    exit 1
-    ;;
-esac
-
-# Not a blocked tool — allow
+# No routes currently match — allow every tool call.
 exit 0


### PR DESCRIPTION
## Summary
- Removes the Gmail and Google Calendar tool redirects from `hooks/tool-router.sh`.
- These redirects previously rewrote `mcp__claude_ai_Gmail__*` and `mcp__claude_ai_Google_Calendar__*` tool calls to `gws gmail` / `gws calendar` shell commands.
- They are now superseded by the dedicated google-services plugin (shipped via wecoded-marketplace#7), which provides first-class `Gmail` / `Drive` / `Docs` / `Sheets` / `Slides` / `Calendar` skills.

## Test plan
- [ ] Run a session and confirm Gmail/Calendar MCP tool invocations route via the google-services plugin without hook interference.
- [ ] Sanity-check that other tool-router redirects still fire (none of the non-Google cases should be affected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)