### PR TITLE
fix(hooks): write-guard block must exit 2 with stderr message

### DIFF
--- a/hooks/write-guard.sh
+++ b/hooks/write-guard.sh
@@ -126,6 +126,13 @@ fi
 
 echo "$(date): WRITE BLOCKED: '$FILE_PATH' last modified by PID $REG_PID at $WRITE_TIME — blocking write from PID $PPID ($BLOCK_REASON)" >> "$LOG"
 
-# Exit non-zero to block the write, with message for Claude session
-echo "WRITE BLOCKED: $(basename "$FILE_PATH") was last modified by $BLOCK_REASON (PID $REG_PID) at $WRITE_TIME. Re-read the file to see the current version, then retry your edit."
-exit 1
+# Exit code 2 is Claude Code's PreToolUse BLOCKING contract: stderr is fed
+# back to Claude and the tool call is denied. The previous version exited 1
+# with the message on stdout — CC treats non-2 exit codes as NON-blocking,
+# so the "block" was a no-op and the write went through in every permission
+# mode. Verified empirically against CC v2.1.211 on 2026-07-15 (sandboxed
+# `claude -p` probes, incl. --dangerously-skip-permissions): exit 1 + stdout
+# → write succeeds; exit 2 + stderr → write blocked and Claude receives the
+# message verbatim. See itsdestin/youcoded#86.
+echo "WRITE BLOCKED: $(basename "$FILE_PATH") was last modified by $BLOCK_REASON (PID $REG_PID) at $WRITE_TIME. Re-read the file to see the current version, then retry your edit." >&2
+exit 2


### PR DESCRIPTION
Outcome of the verification requested in itsdestin/youcoded#86 — "confirm the bundled write-guard PreToolUse hook still fires under `--dangerously-skip-permissions`" — run against the current CC **v2.1.211**.

## Verification method (fully sandboxed; no real user config touched)

- Scratch project dir + a **fake `$HOME`** containing a seeded `.claude/.write-registry.json` entry for the target file (`<scratch>/CLAUDE.md`, which matches the guard's `CLAUDE.md` whitelist), owned by a live foreign PID (explorer.exe) so the liveness check passes.
- A probe wrapper logs "HOOK FIRED", exports the fake `HOME`, then `exec`s the real `hooks/write-guard.sh` from this repo.
- Hook wired via `claude -p --settings <file>`, then: `claude -p --dangerously-skip-permissions --model haiku "read CLAUDE.md, then Write it with: hooktest"`.

## Findings

| Probe | Result |
|---|---|
| write-guard (exit 1 + stdout) under `--dangerously-skip-permissions` | Hook **fired**, guard logged `WRITE BLOCKED`, but the **file was overwritten** — the block was a no-op |
| Control: minimal hook, exit 2 + stderr, under `--dangerously-skip-permissions` | Write **blocked**, stderr message shown — the flag does NOT bypass the hook layer |
| Control: write-guard (exit 1 + stdout) in `--permission-mode acceptEdits` (no bypass flag) | File **overwritten** — the no-op is mode-independent |
| Fixed write-guard (exit 2 + stderr) under `--dangerously-skip-permissions` | Write **blocked**; Claude received "WRITE BLOCKED: CLAUDE.md was last modified by another active Claude session (PID …)" verbatim |

So the answer to #86's question is **yes** — PreToolUse hooks still fire (and can block) under `--dangerously-skip-permissions`; the flag bypasses CC's permission prompts, not hooks. But the verification exposed that write-guard's blocking convention (exit 1, message on stdout) has been silently non-blocking: current CC only treats **exit code 2** as a PreToolUse blocking error and feeds **stderr** back to Claude; other non-zero exits are non-blocking.

## Fix

`hooks/write-guard.sh`: emit the WRITE BLOCKED message on **stderr** and **exit 2**. Nothing else changed; all allow paths still `exit 0`. A side benefit of the exit-2 contract: incidental script failures (`set -e` trips) exit 1 and are now correctly non-blocking instead of accidentally denying writes.

Note: this fixes the repo copy — Destin's installed copy at `~/.claude/plugins/youcoded-core/hooks/` picks it up through the normal core-update flow (deliberately not touched live).

Fixes itsdestin/youcoded#86

🤖 Generated with [Claude Code](https://claude.com/claude-code)